### PR TITLE
apm-agent-go: add Go Runtime Metrics dashboard

### DIFF
--- a/apm-agent-go/dashboards/go_metrics_dashboard_7.x.json
+++ b/apm-agent-go/dashboards/go_metrics_dashboard_7.x.json
@@ -1,0 +1,159 @@
+[
+  {
+    "_id": "ea1cf250-6be1-11e9-9648-cb8c116f841a",
+    "_type": "dashboard",
+    "_source": {
+      "title": "Go Runtime Metrics",
+      "hits": 0,
+      "description": "",
+      "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":0,\"w\":48,\"h\":7,\"i\":\"1\"},\"panelIndex\":\"1\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":7,\"w\":48,\"h\":6,\"i\":\"2\"},\"panelIndex\":\"2\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_1\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":13,\"w\":23,\"h\":6,\"i\":\"4\"},\"panelIndex\":\"4\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_2\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":23,\"y\":13,\"w\":25,\"h\":6,\"i\":\"5\"},\"panelIndex\":\"5\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_3\"},{\"gridData\":{\"x\":0,\"y\":19,\"w\":48,\"h\":6,\"i\":\"6\"},\"version\":\"7.0.0\",\"panelIndex\":\"6\",\"embeddableConfig\":{},\"panelRefName\":\"panel_4\"}]",
+      "optionsJSON": "{\"hidePanelTitles\":false,\"useMargins\":true}",
+      "version": 1,
+      "timeRestore": false,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":null,\"disabled\":false,\"key\":\"agent.name\",\"negate\":false,\"params\":{\"query\":\"go\"},\"type\":\"phrase\",\"value\":\"go\",\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index\"},\"query\":{\"match\":{\"agent.name\":{\"query\":\"go\",\"type\":\"phrase\"}}}}]}"
+      }
+    },
+    "_migrationVersion": {
+      "dashboard": "7.0.0"
+    },
+    "_references": [
+      {
+        "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+        "type": "index-pattern",
+        "id": "apm-*"
+      },
+      {
+        "name": "panel_0",
+        "type": "visualization",
+        "id": "df93a9a0-2fa0-11e9-bf11-ede9e2ea677b"
+      },
+      {
+        "name": "panel_1",
+        "type": "visualization",
+        "id": "a19beed0-6be3-11e9-9648-cb8c116f841a"
+      },
+      {
+        "name": "panel_2",
+        "type": "visualization",
+        "id": "07b860e0-6c9d-11e9-9a58-07a2eed03b22"
+      },
+      {
+        "name": "panel_3",
+        "type": "visualization",
+        "id": "a3782180-6be6-11e9-9648-cb8c116f841a"
+      },
+      {
+        "name": "panel_4",
+        "type": "visualization",
+        "id": "311e3390-6ca4-11e9-9a58-07a2eed03b22"
+      }
+    ]
+  },
+  {
+    "_id": "df93a9a0-2fa0-11e9-bf11-ede9e2ea677b",
+    "_type": "visualization",
+    "_source": {
+      "title": "Service Host Environment Controls",
+      "visState": "{\"title\":\"Service Host Environment Controls\",\"type\":\"input_control_vis\",\"params\":{\"controls\":[{\"id\":\"1550070167115\",\"fieldName\":\"service.name\",\"parent\":\"\",\"label\":\"Services\",\"type\":\"list\",\"options\":{\"type\":\"terms\",\"multiselect\":true,\"dynamicOptions\":true,\"size\":5,\"order\":\"desc\"},\"indexPatternRefName\":\"control_0_index_pattern\"},{\"id\":\"1550070196624\",\"fieldName\":\"host.name\",\"parent\":\"\",\"label\":\"Host\",\"type\":\"list\",\"options\":{\"type\":\"terms\",\"multiselect\":true,\"dynamicOptions\":true,\"size\":5,\"order\":\"desc\"},\"indexPatternRefName\":\"control_1_index_pattern\"},{\"id\":\"1550070239914\",\"fieldName\":\"service.environment\",\"parent\":\"\",\"label\":\"Environment\",\"type\":\"list\",\"options\":{\"type\":\"terms\",\"multiselect\":true,\"dynamicOptions\":true,\"size\":5,\"order\":\"desc\"},\"indexPatternRefName\":\"control_2_index_pattern\"}],\"updateFiltersOnChange\":false,\"useTimeFilter\":false,\"pinFilters\":false},\"aggs\":[]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    },
+    "_migrationVersion": {
+      "visualization": "7.0.0"
+    },
+    "_references": [
+      {
+        "name": "control_0_index_pattern",
+        "type": "index-pattern",
+        "id": "apm-*"
+      },
+      {
+        "name": "control_1_index_pattern",
+        "type": "index-pattern",
+        "id": "apm-*"
+      },
+      {
+        "name": "control_2_index_pattern",
+        "type": "index-pattern",
+        "id": "apm-*"
+      }
+    ]
+  },
+  {
+    "_id": "a3782180-6be6-11e9-9648-cb8c116f841a",
+    "_type": "visualization",
+    "_source": {
+      "title": "[Go] Allocations",
+      "visState": "{\"title\":\"[Go] Allocations\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.objects\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Objects\",\"terms_field\":\"service.name\",\"filter\":\"processor.event: metric\"},{\"id\":\"6740e6d0-6c9e-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"6740e6d1-6c9e-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.mallocs\"},{\"unit\":\"1s\",\"id\":\"ab2c4ab0-6c9e-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"6740e6d1-6c9e-11e9-8a45-e13a52c6b66c\"},{\"unit\":\"\",\"id\":\"e6d21130-6c9e-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"ab2c4ab0-6c9e-11e9-8a45-e13a52c6b66c\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Mallocs\",\"value_template\":\"{{value}}/s\",\"filter\":\"processor.event: metric\"},{\"id\":\"087e0ff0-6c9f-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"087e0ff1-6c9f-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.frees\"},{\"unit\":\"1s\",\"id\":\"087e0ff2-6c9f-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"087e0ff1-6c9f-11e9-8a45-e13a52c6b66c\"},{\"unit\":\"\",\"id\":\"087e0ff3-6c9f-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"087e0ff2-6c9f-11e9-8a45-e13a52c6b66c\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Frees\",\"value_template\":\"{{value}}/s\",\"hidden\":false,\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\"},\"aggs\":[]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    },
+    "_migrationVersion": {
+      "visualization": "7.0.0"
+    },
+    "_references": []
+  },
+  {
+    "_id": "311e3390-6ca4-11e9-9a58-07a2eed03b22",
+    "_type": "visualization",
+    "_source": {
+      "title": "[Go] Garbage Collection",
+      "visState": "{\"title\":\"[Go] Garbage Collection\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"golang.heap.gc.total_count\"},{\"unit\":\"1s\",\"id\":\"6a255730-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"},{\"unit\":\"\",\"id\":\"7764e960-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"6a255730-6ca0-11e9-8a45-e13a52c6b66c\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"value_template\":\"{{value}}/s\",\"label\":\"GC count\",\"filter\":\"processor.event: metric\"},{\"id\":\"d7e75520-6ca0-11e9-8a45-e13a52c6b66c\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"d7e75521-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.gc.total_pause.ns\"},{\"unit\":\"1s\",\"id\":\"f4d7c7a0-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"d7e75521-6ca0-11e9-8a45-e13a52c6b66c\"},{\"unit\":\"\",\"id\":\"feda0920-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"f4d7c7a0-6ca0-11e9-8a45-e13a52c6b66c\"},{\"script\":\"params.total_pause_ns / 1000000\",\"id\":\"e898ff70-6ca7-11e9-93b1-f5139aaf79ba\",\"type\":\"math\",\"variables\":[{\"id\":\"eb6ba770-6ca7-11e9-93b1-f5139aaf79ba\",\"field\":\"feda0920-6ca0-11e9-8a45-e13a52c6b66c\",\"name\":\"total_pause_ns\"}]}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"ms,ms,2\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Pause time\",\"value_template\":\"{{value}} ms/s\",\"split_color_mode\":\"gradient\",\"filter\":\"processor.event: metric\"},{\"id\":\"38dee980-6ca4-11e9-8a45-e13a52c6b66c\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"38dee981-6ca4-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.gc.cpu_fraction\"},{\"script\":\"params.cpu_fraction * 100\",\"id\":\"4479a550-6ca4-11e9-8a45-e13a52c6b66c\",\"type\":\"math\",\"variables\":[{\"id\":\"48915070-6ca4-11e9-8a45-e13a52c6b66c\",\"field\":\"38dee981-6ca4-11e9-8a45-e13a52c6b66c\",\"name\":\"cpu_fraction\"}]}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"CPU Usage\",\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\"},\"aggs\":[]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    },
+    "_migrationVersion": {
+      "visualization": "7.0.0"
+    },
+    "_references": []
+  },
+  {
+    "_id": "a19beed0-6be3-11e9-9648-cb8c116f841a",
+    "_type": "visualization",
+    "_source": {
+      "title": "[Go] Goroutines",
+      "visState": "{\"title\":\"[Go] Goroutines\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"golang.goroutines\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Goroutines\",\"steps\":0,\"series_drop_last_bucket\":1,\"terms_field\":\"service.name\",\"hidden\":false,\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\",\"background_color_rules\":[{\"id\":\"69262800-6be2-11e9-ad48-7f28e717ed4c\"}],\"gauge_color_rules\":[{\"id\":\"6b5fc450-6be2-11e9-ad48-7f28e717ed4c\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"6d1c6870-6be2-11e9-ad48-7f28e717ed4c\"}],\"filter\":\"processor.event : \\\"metric\\\"\"},\"aggs\":[]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    },
+    "_migrationVersion": {
+      "visualization": "7.0.0"
+    },
+    "_references": []
+  },
+  {
+    "_id": "07b860e0-6c9d-11e9-9a58-07a2eed03b22",
+    "_type": "visualization",
+    "_source": {
+      "title": "[Go] Heap",
+      "visState": "{\"title\":\"[Go] Heap\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"56b7eb70-6c9d-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"56b7eb71-6c9d-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.allocated\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Allocated\",\"filter\":\"processor.event: metric\"},{\"id\":\"f23808c0-6c9b-11e9-8a45-e13a52c6b66c\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"f23808c1-6c9b-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.system.obtained\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"System obtained\",\"hidden\":false,\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\"},\"aggs\":[]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    },
+    "_migrationVersion": {
+      "visualization": "7.0.0"
+    },
+    "_references": []
+  }
+]

--- a/apm-agent-go/dashboards/go_metrics_dashboard_7.x.json
+++ b/apm-agent-go/dashboards/go_metrics_dashboard_7.x.json
@@ -6,7 +6,7 @@
       "title": "Go Runtime Metrics",
       "hits": 0,
       "description": "",
-      "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":0,\"w\":48,\"h\":7,\"i\":\"1\"},\"panelIndex\":\"1\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":7,\"w\":48,\"h\":6,\"i\":\"2\"},\"panelIndex\":\"2\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_1\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":13,\"w\":23,\"h\":6,\"i\":\"4\"},\"panelIndex\":\"4\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_2\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":23,\"y\":13,\"w\":25,\"h\":6,\"i\":\"5\"},\"panelIndex\":\"5\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_3\"},{\"gridData\":{\"x\":0,\"y\":19,\"w\":48,\"h\":6,\"i\":\"6\"},\"version\":\"7.0.0\",\"panelIndex\":\"6\",\"embeddableConfig\":{},\"panelRefName\":\"panel_4\"}]",
+      "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"h\":7,\"i\":\"1\",\"w\":48,\"x\":0,\"y\":0},\"panelIndex\":\"1\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":6,\"i\":\"2\",\"w\":48,\"x\":0,\"y\":7},\"panelIndex\":\"2\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_1\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":6,\"i\":\"4\",\"w\":23,\"x\":0,\"y\":13},\"panelIndex\":\"4\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_2\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":6,\"i\":\"5\",\"w\":25,\"x\":23,\"y\":13},\"panelIndex\":\"5\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_3\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":6,\"i\":\"6\",\"w\":48,\"x\":0,\"y\":19},\"panelIndex\":\"6\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_4\"}]",
       "optionsJSON": "{\"hidePanelTitles\":false,\"useMargins\":true}",
       "version": 1,
       "timeRestore": false,
@@ -85,47 +85,29 @@
     ]
   },
   {
-    "_id": "a3782180-6be6-11e9-9648-cb8c116f841a",
-    "_type": "visualization",
-    "_source": {
-      "title": "[Go] Allocations",
-      "visState": "{\"title\":\"[Go] Allocations\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.objects\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Objects\",\"terms_field\":\"service.name\",\"filter\":\"processor.event: metric\"},{\"id\":\"6740e6d0-6c9e-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"6740e6d1-6c9e-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.mallocs\"},{\"unit\":\"1s\",\"id\":\"ab2c4ab0-6c9e-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"6740e6d1-6c9e-11e9-8a45-e13a52c6b66c\"},{\"unit\":\"\",\"id\":\"e6d21130-6c9e-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"ab2c4ab0-6c9e-11e9-8a45-e13a52c6b66c\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Mallocs\",\"value_template\":\"{{value}}/s\",\"filter\":\"processor.event: metric\"},{\"id\":\"087e0ff0-6c9f-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"087e0ff1-6c9f-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.frees\"},{\"unit\":\"1s\",\"id\":\"087e0ff2-6c9f-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"087e0ff1-6c9f-11e9-8a45-e13a52c6b66c\"},{\"unit\":\"\",\"id\":\"087e0ff3-6c9f-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"087e0ff2-6c9f-11e9-8a45-e13a52c6b66c\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Frees\",\"value_template\":\"{{value}}/s\",\"hidden\":false,\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\"},\"aggs\":[]}",
-      "uiStateJSON": "{}",
-      "description": "",
-      "version": 1,
-      "kibanaSavedObjectMeta": {
-        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
-      }
-    },
-    "_migrationVersion": {
-      "visualization": "7.0.0"
-    },
-    "_references": []
-  },
-  {
-    "_id": "311e3390-6ca4-11e9-9a58-07a2eed03b22",
-    "_type": "visualization",
-    "_source": {
-      "title": "[Go] Garbage Collection",
-      "visState": "{\"title\":\"[Go] Garbage Collection\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"golang.heap.gc.total_count\"},{\"unit\":\"1s\",\"id\":\"6a255730-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"},{\"unit\":\"\",\"id\":\"7764e960-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"6a255730-6ca0-11e9-8a45-e13a52c6b66c\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"value_template\":\"{{value}}/s\",\"label\":\"GC count\",\"filter\":\"processor.event: metric\"},{\"id\":\"d7e75520-6ca0-11e9-8a45-e13a52c6b66c\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"d7e75521-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.gc.total_pause.ns\"},{\"unit\":\"1s\",\"id\":\"f4d7c7a0-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"d7e75521-6ca0-11e9-8a45-e13a52c6b66c\"},{\"unit\":\"\",\"id\":\"feda0920-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"f4d7c7a0-6ca0-11e9-8a45-e13a52c6b66c\"},{\"script\":\"params.total_pause_ns / 1000000\",\"id\":\"e898ff70-6ca7-11e9-93b1-f5139aaf79ba\",\"type\":\"math\",\"variables\":[{\"id\":\"eb6ba770-6ca7-11e9-93b1-f5139aaf79ba\",\"field\":\"feda0920-6ca0-11e9-8a45-e13a52c6b66c\",\"name\":\"total_pause_ns\"}]}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"ms,ms,2\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Pause time\",\"value_template\":\"{{value}} ms/s\",\"split_color_mode\":\"gradient\",\"filter\":\"processor.event: metric\"},{\"id\":\"38dee980-6ca4-11e9-8a45-e13a52c6b66c\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"38dee981-6ca4-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.gc.cpu_fraction\"},{\"script\":\"params.cpu_fraction * 100\",\"id\":\"4479a550-6ca4-11e9-8a45-e13a52c6b66c\",\"type\":\"math\",\"variables\":[{\"id\":\"48915070-6ca4-11e9-8a45-e13a52c6b66c\",\"field\":\"38dee981-6ca4-11e9-8a45-e13a52c6b66c\",\"name\":\"cpu_fraction\"}]}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"CPU Usage\",\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\"},\"aggs\":[]}",
-      "uiStateJSON": "{}",
-      "description": "",
-      "version": 1,
-      "kibanaSavedObjectMeta": {
-        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
-      }
-    },
-    "_migrationVersion": {
-      "visualization": "7.0.0"
-    },
-    "_references": []
-  },
-  {
     "_id": "a19beed0-6be3-11e9-9648-cb8c116f841a",
     "_type": "visualization",
     "_source": {
       "title": "[Go] Goroutines",
-      "visState": "{\"title\":\"[Go] Goroutines\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"golang.goroutines\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Goroutines\",\"steps\":0,\"series_drop_last_bucket\":1,\"terms_field\":\"service.name\",\"hidden\":false,\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\",\"background_color_rules\":[{\"id\":\"69262800-6be2-11e9-ad48-7f28e717ed4c\"}],\"gauge_color_rules\":[{\"id\":\"6b5fc450-6be2-11e9-ad48-7f28e717ed4c\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"6d1c6870-6be2-11e9-ad48-7f28e717ed4c\"}],\"filter\":\"processor.event : \\\"metric\\\"\"},\"aggs\":[]}",
+      "visState": "{\"title\":\"[Go] Goroutines\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"golang.goroutines\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Goroutines\",\"steps\":0,\"series_drop_last_bucket\":1,\"terms_field\":\"service.name\",\"hidden\":false,\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\",\"background_color_rules\":[{\"id\":\"69262800-6be2-11e9-ad48-7f28e717ed4c\"}],\"gauge_color_rules\":[{\"id\":\"6b5fc450-6be2-11e9-ad48-7f28e717ed4c\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"6d1c6870-6be2-11e9-ad48-7f28e717ed4c\"}],\"filter\":\"processor.event : \\\"metric\\\"\"},\"aggs\":[]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    },
+    "_migrationVersion": {
+      "visualization": "7.0.0"
+    },
+    "_references": []
+  },
+  {
+    "_id": "a3782180-6be6-11e9-9648-cb8c116f841a",
+    "_type": "visualization",
+    "_source": {
+      "title": "[Go] Allocations",
+      "visState": "{\"title\":\"[Go] Allocations\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.objects\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Objects\",\"terms_field\":\"service.name\",\"filter\":\"processor.event: metric\"},{\"id\":\"6740e6d0-6c9e-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(0,156,224,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"6740e6d1-6c9e-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.mallocs\"},{\"unit\":\"1s\",\"id\":\"ab2c4ab0-6c9e-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"6740e6d1-6c9e-11e9-8a45-e13a52c6b66c\"},{\"unit\":\"\",\"id\":\"e6d21130-6c9e-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"ab2c4ab0-6c9e-11e9-8a45-e13a52c6b66c\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Mallocs\",\"value_template\":\"{{value}}/s\",\"filter\":\"processor.event: metric\",\"split_color_mode\":\"gradient\",\"steps\":0},{\"id\":\"087e0ff0-6c9f-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(0,156,224,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"087e0ff1-6c9f-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.frees\"},{\"unit\":\"1s\",\"id\":\"087e0ff2-6c9f-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"087e0ff1-6c9f-11e9-8a45-e13a52c6b66c\"},{\"unit\":\"\",\"id\":\"087e0ff3-6c9f-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"087e0ff2-6c9f-11e9-8a45-e13a52c6b66c\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Frees\",\"value_template\":\"{{value}}/s\",\"hidden\":false,\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\"},\"aggs\":[]}",
       "uiStateJSON": "{}",
       "description": "",
       "version": 1,
@@ -143,7 +125,25 @@
     "_type": "visualization",
     "_source": {
       "title": "[Go] Heap",
-      "visState": "{\"title\":\"[Go] Heap\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"56b7eb70-6c9d-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"56b7eb71-6c9d-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.allocated\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Allocated\",\"filter\":\"processor.event: metric\"},{\"id\":\"f23808c0-6c9b-11e9-8a45-e13a52c6b66c\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"f23808c1-6c9b-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.system.obtained\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"System obtained\",\"hidden\":false,\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\"},\"aggs\":[]}",
+      "visState": "{\"title\":\"[Go] Heap\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"56b7eb70-6c9d-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"56b7eb71-6c9d-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.allocations.allocated\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Allocated\",\"filter\":\"processor.event: metric\"},{\"id\":\"f23808c0-6c9b-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"f23808c1-6c9b-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.system.obtained\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"System obtained\",\"hidden\":false,\"filter\":\"processor.event: metric\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\"},\"aggs\":[]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    },
+    "_migrationVersion": {
+      "visualization": "7.0.0"
+    },
+    "_references": []
+  },
+  {
+    "_id": "311e3390-6ca4-11e9-9a58-07a2eed03b22",
+    "_type": "visualization",
+    "_source": {
+      "title": "[Go] Garbage Collection",
+      "visState": "{\"title\":\"[Go] Garbage Collection\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"rgba(0,156,224,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"golang.heap.gc.total_count\"},{\"unit\":\"1s\",\"id\":\"6a255730-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"},{\"unit\":\"\",\"id\":\"7764e960-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"6a255730-6ca0-11e9-8a45-e13a52c6b66c\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0.5\",\"stacked\":\"none\",\"value_template\":\"{{value}}/s\",\"label\":\"GC count\",\"filter\":\"processor.event: metric\"},{\"id\":\"d7e75520-6ca0-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"d7e75521-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.gc.total_pause.ns\"},{\"unit\":\"1s\",\"id\":\"f4d7c7a0-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"derivative\",\"field\":\"d7e75521-6ca0-11e9-8a45-e13a52c6b66c\"},{\"unit\":\"\",\"id\":\"feda0920-6ca0-11e9-8a45-e13a52c6b66c\",\"type\":\"positive_only\",\"field\":\"f4d7c7a0-6ca0-11e9-8a45-e13a52c6b66c\"},{\"script\":\"params.total_pause_ns / 1000000\",\"id\":\"e898ff70-6ca7-11e9-93b1-f5139aaf79ba\",\"type\":\"math\",\"variables\":[{\"id\":\"eb6ba770-6ca7-11e9-93b1-f5139aaf79ba\",\"field\":\"feda0920-6ca0-11e9-8a45-e13a52c6b66c\",\"name\":\"total_pause_ns\"}]}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"ms,ms,2\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0.5\",\"stacked\":\"none\",\"label\":\"Pause time\",\"value_template\":\"{{value}} ms/s\",\"split_color_mode\":\"gradient\",\"filter\":\"processor.event: metric\"},{\"id\":\"38dee980-6ca4-11e9-8a45-e13a52c6b66c\",\"color\":\"rgba(25,77,51,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"38dee981-6ca4-11e9-8a45-e13a52c6b66c\",\"type\":\"avg\",\"field\":\"golang.heap.gc.cpu_fraction\"},{\"script\":\"params.cpu_fraction * 100\",\"id\":\"4479a550-6ca4-11e9-8a45-e13a52c6b66c\",\"type\":\"math\",\"variables\":[{\"id\":\"48915070-6ca4-11e9-8a45-e13a52c6b66c\",\"field\":\"38dee981-6ca4-11e9-8a45-e13a52c6b66c\",\"name\":\"cpu_fraction\"}]}],\"separate_axis\":1,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0.5\",\"stacked\":\"none\",\"label\":\"CPU Usage\",\"filter\":\"processor.event: metric\",\"axis_min\":\"0\",\"axis_max\":\"1\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"apm-*\"},\"aggs\":[]}",
       "uiStateJSON": "{}",
       "description": "",
       "version": 1,


### PR DESCRIPTION
Add a dashboard and visualisations for Go runtime
metrics, including:

 - current number of goroutines
 - current heap allocated (in bytes)
 - current heap obtained from system (in bytes)
 - current number of heap-allocated objects
 - mallocs/s and frees/s
 - rate of garbage collections
 - total pause time (as a rate of millis per second)
 - CPU% used by GC

Closes https://github.com/elastic/apm-agent-go/issues/504